### PR TITLE
Add functionality to add and remove colors

### DIFF
--- a/src/Palette.elm
+++ b/src/Palette.elm
@@ -4,13 +4,13 @@ import Json.Decode
 import Char exposing (isHexDigit)
 import Html exposing (div, p, text, input, label, button, Html)
 import Html.Attributes exposing (
-  class, classList, style, type_, value, id, for, attribute
+  class, classList, style, type_, value, id, for, attribute, title
   )
 import Html.Events exposing (onInput, onClick, on, targetValue)
-import Color exposing (Color, white, red)
+import Color exposing (Color, white, red, black)
 import Color.Convert exposing (colorToHex, hexToColor)
 
-import ContrastRatio exposing (areColorsIndistinguishable)
+import ContrastRatio exposing (areColorsIndistinguishable, contrastRatio)
 
 type alias PaletteEntry =
   { id: Int
@@ -98,6 +98,10 @@ squareBgStyle entry =
       [ ("box-shadow", "inset 0 0 0 1px #aeb0b5") ]
       else []
 
+ariaLabel : String -> Html.Attribute msg
+ariaLabel val =
+  attribute "aria-label" val
+
 paletteDiv : Palette -> Bool -> Html PaletteMsg
 paletteDiv palette isEditable =
   let
@@ -143,22 +147,33 @@ paletteDiv palette isEditable =
         actions : List (Html PaletteMsg)
         actions =
           if isEditable && (List.length palette > 1) then
-            [ button [ onClick (Remove entry.id)
-                     , class "usa-button-gray palette-action-remove"
-                     ]
-                [ text "Remove" ]
-            ]
+            let
+              labelText = "Remove color " ++ entry.name
+              isLight = contrastRatio entry.color black >
+                        contrastRatio entry.color white
+            in
+              [ button [ onClick (Remove entry.id)
+                       , classList [ ("usa-button-outline-inverse", True)
+                                   , ("palette-action-remove", True)
+                                   , ("palette-entry-is-light", isLight)
+                                   ]
+                       , ariaLabel labelText
+                       , title labelText
+                       ]
+                  [ text "×" ]
+              ]
           else []
       in
         div [ classList [ ("usa-color-square", True)
                         , ("usa-mobile-end-row", isOdd i)
                         ]
             , style (squareBgStyle entry) ]
-          [ div [ class "usa-color-inner-content" ]
-            ([ p [ class "usa-color-name" ] (entryName entry)
+          (actions ++
+           [ div [ class "usa-color-inner-content" ]
+             [ p [ class "usa-color-name" ] (entryName entry)
              , p [ class "usa-color-hex" ] (entryHex entry)
-             ] ++ actions)
-          ]
+             ]
+           ])
   in
     div [ classList [ ("usa-grid-full", True)
                     , ("usa-color-row", True)

--- a/src/Palette.elm
+++ b/src/Palette.elm
@@ -2,11 +2,11 @@ module Palette exposing (..)
 
 import Json.Decode
 import Char exposing (isHexDigit)
-import Html exposing (div, p, text, input, label, Html)
+import Html exposing (div, p, text, input, label, button, Html)
 import Html.Attributes exposing (
   class, classList, style, type_, value, id, for, attribute
   )
-import Html.Events exposing (onInput, on, targetValue)
+import Html.Events exposing (onInput, onClick, on, targetValue)
 import Color exposing (Color, white, red)
 import Color.Convert exposing (colorToHex, hexToColor)
 
@@ -23,7 +23,10 @@ type alias Palette = List PaletteEntry
 
 type alias SerializedPalette = List (String, String)
 
-type PaletteMsg = ChangeName Int String | ChangeColor Int String
+type PaletteMsg =
+  ChangeName Int String
+  | ChangeColor Int String
+  | Remove Int
 
 updatePalette : PaletteMsg -> Palette -> Palette
 updatePalette msg palette =
@@ -43,6 +46,8 @@ updatePalette msg palette =
         List.map
           (\e -> if e.id == id then (changeColor e) else e)
           palette
+    Remove id ->
+      List.filter (\e -> e.id /= id) palette
 
 deserializePalette : SerializedPalette -> Palette
 deserializePalette items =
@@ -134,15 +139,26 @@ paletteDiv palette isEditable =
 
     square : Int -> PaletteEntry -> Html PaletteMsg
     square i entry =
-      div [ classList [ ("usa-color-square", True)
-                      , ("usa-mobile-end-row", isOdd i)
-                      ]
-          , style (squareBgStyle entry) ]
-        [ div [ class "usa-color-inner-content" ]
-          [ p [ class "usa-color-name" ] (entryName entry)
-          , p [ class "usa-color-hex" ] (entryHex entry)
+      let
+        actions : List (Html PaletteMsg)
+        actions =
+          if isEditable && (List.length palette > 1) then
+            [ button [ onClick (Remove entry.id)
+                     , class "usa-button-gray palette-action-remove"
+                     ]
+                [ text "Remove" ]
+            ]
+          else []
+      in
+        div [ classList [ ("usa-color-square", True)
+                        , ("usa-mobile-end-row", isOdd i)
+                        ]
+            , style (squareBgStyle entry) ]
+          [ div [ class "usa-color-inner-content" ]
+            ([ p [ class "usa-color-name" ] (entryName entry)
+             , p [ class "usa-color-hex" ] (entryHex entry)
+             ] ++ actions)
           ]
-        ]
   in
     div [ classList [ ("usa-grid-full", True)
                     , ("usa-color-row", True)

--- a/static/index.html
+++ b/static/index.html
@@ -28,7 +28,13 @@ main {
 }
 
 .usa-primary-color-section.palette-is-editable .usa-color-square {
-  margin-bottom: 12rem;
+  margin-bottom: 16rem;
+}
+
+.palette-action-remove {
+  width: 100%;
+  margin-top: 0;
+  font-size: 1rem;
 }
 </style>
 <title>Accessible color palette builder</title>

--- a/static/index.html
+++ b/static/index.html
@@ -28,13 +28,32 @@ main {
 }
 
 .usa-primary-color-section.palette-is-editable .usa-color-square {
-  margin-bottom: 16rem;
+  margin-bottom: 12rem;
 }
 
-.palette-action-remove {
-  width: 100%;
-  margin-top: 0;
-  font-size: 1rem;
+button.palette-action-remove.palette-entry-is-light {
+  /* Use USWDS "gray-dark" if we're displaying the button on
+   * a light background. */
+  color: #323a45;
+  box-shadow: inset 0 0 0 2px #323a45;
+}
+
+button.palette-action-remove.palette-entry-is-light:focus {
+  box-shadow: inset 0 0 0 2px #aeb0b5;
+}
+
+button.palette-action-remove.palette-entry-is-light:hover {
+  color: #aeb0b5;
+  box-shadow: inset 0 0 0 2px #aeb0b5;
+}
+
+button.palette-action-remove {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  padding: 0.5rem;
+  margin: 0;
+  line-height: 0.75;
 }
 </style>
 <title>Accessible color palette builder</title>

--- a/static/index.html
+++ b/static/index.html
@@ -55,6 +55,18 @@ button.palette-action-remove {
   margin: 0;
   line-height: 0.75;
 }
+
+.palette-action-add-wrapper {
+  box-shadow: inset 0 0 0 1px #f0f0f0;
+}
+
+.palette-action-add-wrapper button {
+  position: absolute;
+  top: calc(50% - 2.5rem);
+  left: calc(50% - 1.5rem);
+  padding: 1rem;
+  line-height: 0.75;
+}
 </style>
 <title>Accessible color palette builder</title>
 <main id="main"></main>


### PR DESCRIPTION
Users can edit colors, but they can't add or remove them!

With this PR, they can:

> ![add-remove-colors](https://cloud.githubusercontent.com/assets/124687/21743830/6a915b18-d4d8-11e6-8d98-529a23763dd5.png)
